### PR TITLE
Fixed excetion trace logging

### DIFF
--- a/data-pipeline-flink/rating/src/main/scala/org/sunbird/dp/rating/function/RatingFunction.scala
+++ b/data-pipeline-flink/rating/src/main/scala/org/sunbird/dp/rating/function/RatingFunction.scala
@@ -125,7 +125,7 @@ class RatingFunction(config: RatingConfig, @transient var cassandraUtil: Cassand
       case ex: Exception =>
         context.output(config.failedEvent, event)
         // log full message + stack trace through logger
-        logger.error(s"Exception while processing eventId=${event.activityId}", ex)
+        logger.error(s"Exception while processing event for activityId=${event.activityId}", ex)
     }
   }
 

--- a/data-pipeline-flink/rating/src/main/scala/org/sunbird/dp/rating/function/RatingFunction.scala
+++ b/data-pipeline-flink/rating/src/main/scala/org/sunbird/dp/rating/function/RatingFunction.scala
@@ -122,11 +122,10 @@ class RatingFunction(config: RatingConfig, @transient var cassandraUtil: Cassand
       }
       saveRatingLookup(event)
     } catch {
-      case ex: Exception => {
-        ex.printStackTrace()
+      case ex: Exception =>
         context.output(config.failedEvent, event)
-        logger.info("Event throwing exception: ", ex.getMessage)
-      }
+        // log full message + stack trace through logger
+        logger.error(s"Exception while processing eventId=${event.activityId}", ex)
     }
   }
 


### PR DESCRIPTION
KB-11608: Rating Flink Job Exception Logging Issue

The statement logger.error("Event throwing exception: ", ex.getMessage) uses an incorrect logging syntax. When passing arguments to a formatted log message, placeholders (like {}) must be used, and in this case, one was missing.
The correct overloaded error methods are:

void error(String msg);
void error(String format, Object arg);
void error(String format, Object arg1, Object arg2);
void error(String msg, Throwable t);

For example, if you just want to log the message and the exception’s message text:
logger.error("Event throwing exception: {}", ex.getMessage());

If you want to log the full stack trace of the exception:
logger.error("Event throwing exception", ex);